### PR TITLE
Pi-Star Dashboard v20181020 - Added i8ln and language file lookups for all POCSAG / DAPNET Labels, Headers etc

### DIFF
--- a/lang/catalan_es.php
+++ b/lang/catalan_es.php
@@ -115,21 +115,26 @@ $lang = array (
   "p25_net"                     =>  "Xarxa P25",
   "nxdn_radio"                  =>  "Radio NXDN",
   "nxdn_net"                    =>  "Xarxa NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Hora",
   "mode"                        =>  "Mode",
   "callsign"                    =>  "Indicatiu",
   "target"                      =>  "Destí",
-  "src"                         =>  "SRC",  
-  "dur"                         =>  "DUR",  
+  "src"                         =>  "SRC",
+  "dur"                         =>  "DUR",
   "loss"                        =>  "Pèrdua",
-  "ber"                         =>  "BER",  
+  "ber"                         =>  "BER",
   // Dashboard - Extra Info
   "group"                       =>  "Grup",
   "logoff"                      =>  "Finalitzar",
   "info"                        =>  "Informació",
-  "utot"                        =>  "UTOT", 
-  "gtot"                        =>  "GTOT", 
+  "utot"                        =>  "UTOT",
+  "gtot"                        =>  "GTOT",
   // Dashboard Front Page / Admin - Section Headders
   "last_heard_list"             =>  "Últimes 20 trucades rebudes",
   "local_tx_list"               =>  "Últimes 20 trucades rebudes via radio",
@@ -137,6 +142,15 @@ $lang = array (
   "active_starnet_members"      =>  "Membres actius grup Starnet",
   "d-star_link_manager"         =>  "Gestor d'enllaços D-Star",
   "d-star_link_status"          =>  "Informació d'enllaços D-Star",
-  "service_status"              =>  "Estat del servei"
+  "service_status"              =>  "Estat del servei",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/chinese_cn.php
+++ b/lang/chinese_cn.php
@@ -2,7 +2,7 @@
 // Chinese CN (simplified Chinese characters) Language Pack
 // Translated by Le Peng（BD7KLE）, Email: bd7kle@gmail.com
 //               Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com
-// Maintained by Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com 
+// Maintained by Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com
 // Last update on 03/08/2017
 
 $lang = array (
@@ -114,6 +114,12 @@ $lang = array (
   "p25_net"                     =>  "P25 网络",
   "nxdn_radio"                  =>  "NXDN 电台",
   "nxdn_net"                    =>  "NXDN 网络",
+
+    // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+    // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "时间",
   "mode"                        =>  "模式",
@@ -136,6 +142,15 @@ $lang = array (
   "active_starnet_members"      =>  "激活的 Starnet 组成员",
   "d-star_link_manager"         =>  "D-Star 连接管理器",
   "d-star_link_status"          =>  "D-Star 连接信息",
-  "service_status"              =>  "服务状态"
+  "service_status"              =>  "服务状态",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/chinese_hk.php
+++ b/lang/chinese_hk.php
@@ -2,7 +2,7 @@
 // Chinese HK (Traditional Chinese characters) Language Pack
 // Translated by Le Peng（BD7KLE）, Email: bd7kle@gmail.com
 //               Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com
-// Maintained by Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com 
+// Maintained by Yuan Wang（BG3MDO）, Email: bg3mdo@gmail.com
 // Last update on 03/08/2017
 
 $lang = array (
@@ -114,6 +114,12 @@ $lang = array (
   "p25_net"                     =>  "P25 網絡",
   "nxdn_radio"                  =>  "NXDN 電臺",
   "nxdn_net"                    =>  "NXDN 網絡",
+
+    // TODO: Needs experienced language translation
+    "pocsag_paging"               =>  "POCSAG Paging",
+    "dapnet_net"                  =>  "DAPNET Gateway",
+    // TODO: ----
+      
   // Dashboard Front Page - Calls
   "time"                        =>  "時間",
   "mode"                        =>  "模式",
@@ -136,6 +142,15 @@ $lang = array (
   "active_starnet_members"      =>  "激活 Starnet 組成員",
   "d-star_link_manager"         =>  "D-Star 連接管理器",
   "d-star_link_status"          =>  "D-Star 連接信息",
-  "service_status"              =>  "服務狀態"
+  "service_status"              =>  "服務狀態",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/chinese_tw.php
+++ b/lang/chinese_tw.php
@@ -112,6 +112,12 @@ $lang = array (
   "p25_net"                     =>  "P25 網路",
   "nxdn_radio"                  =>  "NXDN 電台",
   "nxdn_net"                    =>  "NXDN 網路",
+
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "時間",
   "mode"                        =>  "模式",
@@ -134,6 +140,15 @@ $lang = array (
   "active_starnet_members"      =>  "啟用 Starnet 成員",
   "d-star_link_manager"         =>  "D-Star 連線管理",
   "d-star_link_status"          =>  "D-Star 連線狀態",
-  "service_status"              =>  "服務狀態"
+  "service_status"              =>  "服務狀態",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/dutch_nl.php
+++ b/lang/dutch_nl.php
@@ -113,6 +113,8 @@ $lang = array (
   "p25_net"                     =>  "P25 netwerk",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN netwerk",
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
   // Dashboard Front Page - Calls
   "time"                        =>  "Tijd",
   "mode"                        =>  "Mode",
@@ -120,7 +122,7 @@ $lang = array (
   "target"                      =>  "Doel",
   "src"                         =>  "Bron",        // Short version of "Source"
   "dur"                         =>  "Duur",        // Short version of "Duration"
-  "loss"                        =>  "Verlies", 
+  "loss"                        =>  "Verlies",
   "ber"                         =>  "BER",        // Short version of "Bit Error Rate"
   // Dashboard - Extra Info
   "group"                       =>  "Groep",
@@ -135,6 +137,12 @@ $lang = array (
   "active_starnet_members"      =>  "Actieve Starnet groepsleden",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Informatie",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Paging-bericht Tx-activiteit",
+  "timeslot"                    =>  "Tijdslot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Bericht Tekst",
+  "whitelist"                   =>  "Whitelist"
 );
 ?>

--- a/lang/english_uk.php
+++ b/lang/english_uk.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "P25 Network",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Network",
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
   // Dashboard Front Page - Calls
   "time"                        =>  "Time",
   "mode"                        =>  "Mode",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Active Starnet Group Members",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Information",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
 );
 ?>

--- a/lang/english_us.php
+++ b/lang/english_us.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "P25 Network",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Network",
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
   // Dashboard Front Page - Calls
   "time"                        =>  "Time",
   "mode"                        =>  "Mode",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Active Starnet Group Members",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Information",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
 );
 ?>

--- a/lang/french_fr.php
+++ b/lang/french_fr.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "R&eacute;seau P25",
   "nxdn_radio"                  =>  "Radio NXDN",
   "nxdn_net"                    =>  "R&eacute;seau NXDN",
+  "pocsag_paging"               =>  "POCSAG Téléavertisseur",
+  "dapnet_net"                  =>  "DAPNET Passerelle",
   // Dashboard Front Page - Calls
   "time"                        =>  "Heure",
   "mode"                        =>  "Mode",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Active Starnet Group Members",
   "d-star_link_manager"         =>  "Administrateur du lien D-Star",
   "d-star_link_status"          =>  "Informations du lien D-Star",
-  "service_status"              =>  "&Eacute;tat du service"
+  "service_status"              =>  "&Eacute;tat du service",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Activité de Message de Pageur",
+  "timeslot"                    =>  "Intervalle de Temps",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Liste Blanche"
 );
 ?>

--- a/lang/german_de.php
+++ b/lang/german_de.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "P25 Netzwerk",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Netzwerk",
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Netzwerk",
   // Dashboard Front Page - Calls
   "time"                        =>  "Zeit",
   "mode"                        =>  "Mode",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Aktive Starnet Gruppen Mitglieder",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Information",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Nachricht Tx Aktivitat",
+  "timeslot"                    =>  "Zeitfenster",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Nachrichtentext",
+  "whitelist"                   =>  "Weise Liste"
   );
 ?>

--- a/lang/greek_gr.php
+++ b/lang/greek_gr.php
@@ -114,6 +114,12 @@ $lang = array (
   "p25_net"                     =>  "Δίκτυο P25",
   "nxdn_radio"                  =>  "Ασύρματος NXDN",
   "nxdn_net"                    =>  "Δίκτυο NXDN",
+
+  // TODO: Needs Greek language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Ωρα",
   "mode"                        =>  "Λειτουργία",
@@ -136,6 +142,15 @@ $lang = array (
   "active_starnet_members"      =>  "Ενεργά Μέλη Ομάδων Starnet",
   "d-star_link_manager"         =>  "Διαχειριστής Ζεύζης D-Star",
   "d-star_link_status"          =>  "Πληροφορίες Ζεύξης D-Star",
-  "service_status"              =>  "Κατάσταση Υπηρεσίας"
+  "service_status"              =>  "Κατάσταση Υπηρεσίας",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs Greek language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/italian_it.php
+++ b/lang/italian_it.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "P25 Network",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Network",
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
   // Dashboard Front Page - Calls
   "time"                        =>  "Ora",
   "mode"                        =>  "Modo",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Menbri Attivi Nel Gruppo Starnet",
   "d-star_link_manager"         =>  "Gestione D-Star Link",
   "d-star_link_status"          =>  "Info D-Star Link",
-  "service_status"              =>  "Stato Servizi"
+  "service_status"              =>  "Stato Servizi",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Attività di Ricerca Messaggi di Paging",
+  "timeslot"                    =>  "Fascia Oraria",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Messaggio di testo",
+  "whitelist"                   =>  "Lista bianca"
 );
 ?>

--- a/lang/japanese_jp.php
+++ b/lang/japanese_jp.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "P25 Network",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Network",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "時刻",
   "mode"                        =>  "モード",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Active Starnet Group Members",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Information",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/norwegian_no.php
+++ b/lang/norwegian_no.php
@@ -114,6 +114,8 @@ $lang = array (
   "p25_net"                     =>  "P25 Nettverk",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN Nettverk",
+  "pocsag_paging"               =>  "POCSAG Personsøkingssystem",
+  "dapnet_net"                  =>  "DAPNET Nettverk",
   // Dashboard Front Page - Calls
   "time"                        =>  "Tid",
   "mode"                        =>  "Mode",
@@ -136,6 +138,12 @@ $lang = array (
   "active_starnet_members"      =>  "Aktive Starnet Gruppe medlemer",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "D-Star Link Informasjon",
-  "service_status"              =>  "Service Status"
+  "service_status"              =>  "Service Status",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Aktivitet",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Meldingstekst",
+  "whitelist"                   =>  "Hviteliste"
 );
 ?>

--- a/lang/portuguese_br.php
+++ b/lang/portuguese_br.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "Rede P25",
   "nxdn_radio"                  =>  "Rádio NDXN",
   "nxdn_net"                    =>  "Rede NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Hora",
   "mode"                        =>  "Modo",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Grupo de Membros Ativos na Starnet",
   "d-star_link_manager"         =>  "Gerenciar Conexão D-Star",
   "d-star_link_status"          =>  "Informações do Link D-Star",
-  "service_status"              =>  "Status do Sistema"
+  "service_status"              =>  "Status do Sistema",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/portuguese_pt.php
+++ b/lang/portuguese_pt.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "Rede P25",
   "nxdn_radio"                  =>  "Rádio NXDN",
   "nxdn_net"                    =>  "Rede NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Hora",
   "mode"                        =>  "Modo",
@@ -136,7 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Grupo de membros ativos na Starnet",
   "d-star_link_manager"         =>  "Gerir a ligação DSTAR",
   "d-star_link_status"          =>  "Informações do Link DSTAR",
-  "service_status"              =>  "Estado do Sistema"
+  "service_status"              =>  "Estado do Sistema",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>
- 

--- a/lang/romanian_ro.php
+++ b/lang/romanian_ro.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "Reteaua P25",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "Reteaua NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Ora",
   "mode"                        =>  "Mod",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Membrii activi in Grupuri Starnet ",
   "d-star_link_manager"         =>  "D-Star Link Manager",
   "d-star_link_status"          =>  "Informatii Legatura D-Star",
-  "service_status"              =>  "Stare Serviciu"
+  "service_status"              =>  "Stare Serviciu",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/spanish_es.php
+++ b/lang/spanish_es.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "Red de P25",
   "nxdn_radio"                  =>  "Radio de NXDN",
   "nxdn_net"                    =>  "Red de NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Hora",
   "mode"                        =>  "Modo",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Miembros activos del grupo Starnet",
   "d-star_link_manager"         =>  "Gestor de enlaces D-Star",
   "d-star_link_status"          =>  "Informacion de enlaces D-Star",
-  "service_status"              =>  "Estado del servicio"
+  "service_status"              =>  "Estado del servicio",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/spanish_mx.php
+++ b/lang/spanish_mx.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "P25 red",
   "nxdn_radio"                  =>  "NXDN Radio",
   "nxdn_net"                    =>  "NXDN red",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+
   // Dashboard Front Page - Calls
   "time"                        =>  "Time",
   "mode"                        =>  "Modo",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Activo miembros de grupo Starnet",
   "d-star_link_manager"         =>  "D-Star gestar de enlaces",
   "d-star_link_status"          =>  "D-Star Informacion de enlaces",
-  "service_status"              =>  "Estado servicio"
+  "service_status"              =>  "Estado servicio",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/lang/thai_th.php
+++ b/lang/thai_th.php
@@ -114,6 +114,11 @@ $lang = array (
   "p25_net"                     =>  "เครือข่าย P25",
   "nxdn_radio"                  =>  "วิทยุ NXDN",
   "nxdn_net"                    =>  "เครือข่าย NXDN",
+  // TODO: Needs experienced language translation
+  "pocsag_paging"               =>  "POCSAG Paging",
+  "dapnet_net"                  =>  "DAPNET Gateway",
+  // TODO: ----
+  
   // Dashboard Front Page - Calls
   "time"                        =>  "เวลา",
   "mode"                        =>  "โหมด",
@@ -136,6 +141,15 @@ $lang = array (
   "active_starnet_members"      =>  "Active Starnet Group Members",
   "d-star_link_manager"         =>  "จัดการการเชื่อมต่อของ D-Star",
   "d-star_link_status"          =>  "ข้อมูลการเชื่อมต่อของ D-Star",
-  "service_status"              =>  "สถานะของระบบ"
+  "service_status"              =>  "สถานะของระบบ",
+  // Dashboard - POCSAG / DAPNET Status and Activity
+
+  // TODO: Needs experienced language translation
+  "dapnet_activity_hdr"         =>  "POCSAG Paging Message Tx Activity",
+  "timeslot"                    =>  "TimeSlot",
+  "pager_ric"                   =>  "Pager RIC",
+  "message_text"                =>  "Message Text",
+  "whitelist"                   =>  "Whitelist"
+  // TODO: ----
 );
 ?>

--- a/mmdvmhost/dapnetTx.php
+++ b/mmdvmhost/dapnetTx.php
@@ -12,18 +12,16 @@ $reverseDapnetMessageLog = $dapnetMessageLog;
 array_multisort($reverseDapnetMessageLog, SORT_DESC);
 
 if ($isPocsagEnabled) {
-    //TODO: Ben Horan <benh@geeksforhire.com.au> 2018-10-20
-    //TODO: Add language internationalisation functionality and language packs rather than hardcoded English labels
 ?>
 
-<b>POCSAG Paging Message Tx Activity</b>
+<b><?php echo $lang['dapnet_activity_hdr'];?></b>
 
 <table>
   <tr>
     <th><a class="tooltip" href="#"><?php echo $lang['time'];?> (<?php echo date('T')?>)<span><b>Time in <?php echo date('T')?> time zone</b></span></a></th>
-    <th><a class="tooltip" href="#">TimeSlot<span><b>Message Mode</b></span></a></th>
-    <th><a class="tooltip" href="#">Pager RIC<span><b>RIC / CapCode of the receiving Pager</b></span></a></th>
-    <th><a class="tooltip" href="#">Message<span><b>Message contents</b></span></a></th>
+    <th><a class="tooltip" href="#"><?php echo $lang['timeslot'];?><span><b>Message Mode</b></span></a></th>
+    <th><a class="tooltip" href="#"><?php echo $lang['pager_ric'];?><span><b>RIC / CapCode of the receiving Pager</b></span></a></th>
+    <th><a class="tooltip" href="#"><?php echo $lang['message_text'];?><span><b>Message contents</b></span></a></th>
     <th><a class="tooltip" href="#"><?php echo $lang['src'];?><span><b>Recieved from source</b></span></a></th>
   </tr>
 
@@ -35,8 +33,6 @@ if ($isPocsagEnabled) {
       $dt = new DateTime($utc_time, $utc_tz);
       $dt->setTimeZone($local_tz);
       $local_time = $dt->format('H:i:s M jS');
-      //DEBUG:
-      //echo '<!-- DEBUG:  $utc_time = ' . $utc_time . ', $local_time = ' . $local_time . '-->';
 ?>
 
   <tr>

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -325,14 +325,14 @@ if (($testMMDVModePOCSAG1 == 1) && ($testMMDVModePOCSAG2 == 1 )) {
 
   echo "<br />\n";
   echo "<table>\n";
-  echo "<tr><th colspan=\"2\">POCSAG Paging</th></tr>\n";
+  echo "<tr><th colspan=\"2\">".$lang['pocsag_paging']."</th></tr>\n";
   echo "<tr><th>Tx</th><td style=\"background: #ffffff;\">" . $pocsagFrequencyDisplay . "</td></tr>";
   if (isset($configdapnetgateway['General']['Callsign'])) {
-      echo "<tr><th>Callsign</th><td style=\"background: #ffffff;\">".str_replace(' ', '&nbsp;', $configdapnetgateway['General']['Callsign'])."</td></tr>\n";
+      echo "<tr><th>".$lang['callsign']."</th><td style=\"background: #ffffff;\">".str_replace(' ', '&nbsp;', $configdapnetgateway['General']['Callsign'])."</td></tr>\n";
   }
   if (isset($configdapnetgateway['General']['WhiteList'])) {
     $whitelistedRics = explode(",", $configdapnetgateway['General']['WhiteList']);
-    echo "<tr><th>Whitelist</th><td style=\"background: #ffffff; text-align: center;\">";
+    echo "<tr><th>".$lang['whitelist']."</th><td style=\"background: #ffffff; text-align: center;\">";
     foreach($whitelistedRics as $currentRic) {
       echo sprintf("%07d", trim($currentRic)) . "<br/>";
     }


### PR DESCRIPTION
**Pi-Star Dashboard v20181020** - Added i8ln and language file lookups for all POCSAG / DAPNET Labels, Headers etc *(replacing all hard-coded English in PHP/HTML)*.

Attempted to translate new **$lang** entries into native language text in as many languages as possible from the many language packs in **/lang** folder *(some additional assistance required from people who are bi-lingual in some of the trickier languages)*...  :nerd_face: 

```
- ADDED: Added language i8ln lookups to all headers, labels, etc added for POCSAG/DAPNET
         Dashboard enhancements ("dapnetTx.php" and "repeaterinfo.php"),
         replacing all hard-coded English labels etc for easy translation.

- ADDED: Inserted needed $lang lookup values for i8ln into ALL of the files in the /lang folder
         (NOTE: Google Translate was best I could use. Some languages not translated - 
          Original English words are in place where translation not viable!)

- TODO:  Obtain translation assistance for language text /lang/*.php language files
         (NOTE: files needing work are flagged with a: 
          "TODO: Needs experienced language translation" comment in the sections of 
          file that need more specialised than simple online translator site can provide).

- NOTE:  Fully complete i8ln lang files (hopefully make sense to people in their native 
         language) are:

             - dutch_nl.php, 
             - english_uk.php,  
             - english_us.php, 
             - french_fr.php, 
             - german_de.php, 
             - italian_it.php, 
             - norwegian_no.php
```